### PR TITLE
Update weui_cell_global.less

### DIFF
--- a/src/style/widget/weui_cell/weui_cell_global.less
+++ b/src/style/widget/weui_cell/weui_cell_global.less
@@ -66,5 +66,5 @@
 }
 
 .weui_cell_primary {
-    flex: 1;
+    flex: 1 0 auto;
 }


### PR DESCRIPTION
修复微信浏览器下cell右侧内容过长导致title换行的bug
